### PR TITLE
tools: Add nfd-start-fg.sh

### DIFF
--- a/tools/nfd-start-fg.sh
+++ b/tools/nfd-start-fg.sh
@@ -22,6 +22,7 @@ esac
 
 nfd-start || exit $?
 
-read -p 'To stop, hit ENTER or CTRL-C '
+echo "To stop, hit ENTER or CTRL-C"
+read
 
 nfd-stop || exit $?


### PR DESCRIPTION
This is e.g. for Docker, where (by convention and best practice) one container
should really only run one process.
