### PR TITLE
fix typos in manpages,

### DIFF
--- a/docs/manpages/ndn-autoconfig-server.rst
+++ b/docs/manpages/ndn-autoconfig-server.rst
@@ -19,7 +19,7 @@ Description
 
 This daemon essentially waits for Interests for ``/localhop/ndn-autoconf/hub`` and
 satisfies them with a Data packet that contains TLV-encoded FaceUri block.  The value of
-this block is the ``Uri`` for the HUB, preferrably a UDP tunnel.
+this block is the ``Uri`` for the HUB, preferably a UDP tunnel.
 
 ``-h``
   print usage and exit.

--- a/docs/manpages/nfd-autoreg.rst
+++ b/docs/manpages/nfd-autoreg.rst
@@ -11,7 +11,7 @@ Usage
 Description
 -----------
 
-``autoreg-server`` is a deamon application that automatically registers the specified
+``autoreg-server`` is a daemon application that automatically registers the specified
 prefix(es) when new on-demand Face is created (i.e., when a new UDP face is created
 as a result of an incoming packet or TCP face is created as a result of an incoming
 connection).


### PR DESCRIPTION
at @endlssm we're working on integrating NFD into our distro,
as we were doing the debian package lintian found a few typos in the manpages,
here comes the patch.

kudos to lintian for finding those out

Signed-off-by: Niv Sardi <xaiki@evilgiggle.com>