### PR TITLE
An error occurred in nfd.conf when enabling localhop_security & prefix-propagate features. 

### DIFF
--- a/daemon/rib/service.cpp
+++ b/daemon/rib/service.cpp
@@ -168,7 +168,10 @@ Service::checkConfig(const ConfigSection& section, const std::string& filename)
     const std::string& key = item.first;
     const ConfigSection& value = item.second;
     if (key == CFG_LOCALHOST_SECURITY || key == CFG_LOCALHOP_SECURITY || key == CFG_PA_VALIDATION) {
-      hasLocalhop = key == CFG_LOCALHOP_SECURITY;
+      //hasLocalhop = key == CFG_LOCALHOP_SECURITY;
+      if( key == CFG_LOCALHOP_SECURITY )
+           hasLocalhop = true;
+
       ndn::ValidatorConfig testValidator(m_face);
       testValidator.load(value, filename);
     }


### PR DESCRIPTION
auto_prefix_propagate and localhop_security cannot be enabled at the same time.
However, when I enable the both in NFD.CONF, hasLocalhop is always false.
So, I modified the source code to fix it.